### PR TITLE
Fix typo in vqaEval.py

### DIFF
--- a/PythonEvaluationTools/vqaEvaluation/vqaEval.py
+++ b/PythonEvaluationTools/vqaEvaluation/vqaEval.py
@@ -179,7 +179,7 @@ class VQAEval:
 			progress = 1
 			status = "Done...\r\n"
 		block = int(round(barLength*progress))
-		text = "\rFinshed Percent: [{0}] {1}% {2}".format( "#"*block + "-"*(barLength-block), int(progress*100), status)
+		text = "\rFinished Percent: [{0}] {1}% {2}".format( "#"*block + "-"*(barLength-block), int(progress*100), status)
 		sys.stdout.write(text)
 		sys.stdout.flush()
 


### PR DESCRIPTION
Fixes a typo ("Finshed" -> "Finished").